### PR TITLE
fixed blocks API issue

### DIFF
--- a/src/api/http/blocks.js
+++ b/src/api/http/blocks.js
@@ -29,11 +29,6 @@ const constants = require('../../helpers/constants');
 function BlocksHttpApi(blocksModule, app, logger, cache) {
     const router = new Router();
 
-    // attach a middlware to endpoints
-    router.attachMiddlwareForUrls(httpApi.middleware.useCache.bind(null, logger, cache), [
-        'get /'
-    ]);
-
     router.map(blocksModule.shared, {
         'get /get': 'getBlock',
         'get /': 'getBlocks',


### PR DESCRIPTION
getBlocks API provides inconsistent data due to cache implementation for this API. It is not real time data as it comes from a cache storage.